### PR TITLE
[Feat] #10 - 원격줄서기 완료 팝업 뷰 구현

### DIFF
--- a/Tabling-iOS/Tabling-iOS.xcodeproj/project.pbxproj
+++ b/Tabling-iOS/Tabling-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		A461B5E92B08ECC70049A0F3 /* ImageLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5E82B08ECC70049A0F3 /* ImageLiterals.swift */; };
 		A461B5EB2B08ED540049A0F3 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5EA2B08ED540049A0F3 /* UIImage+.swift */; };
 		A461B5ED2B08F6900049A0F3 /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5EC2B08F6900049A0F3 /* StringLiterals.swift */; };
+		A461B5F12B0BE0AD0049A0F3 /* ReserveEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5F02B0BE0AD0049A0F3 /* ReserveEntity.swift */; };
+		A461B5F82B0C589B0049A0F3 /* ReserveAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5F72B0C589B0049A0F3 /* ReserveAlertView.swift */; };
+		A461B5FA2B0C58A70049A0F3 /* ReserveAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461B5F92B0C58A70049A0F3 /* ReserveAlertViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -80,6 +83,9 @@
 		A461B5E82B08ECC70049A0F3 /* ImageLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiterals.swift; sourceTree = "<group>"; };
 		A461B5EA2B08ED540049A0F3 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		A461B5EC2B08F6900049A0F3 /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
+		A461B5F02B0BE0AD0049A0F3 /* ReserveEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReserveEntity.swift; sourceTree = "<group>"; };
+		A461B5F72B0C589B0049A0F3 /* ReserveAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReserveAlertView.swift; sourceTree = "<group>"; };
+		A461B5F92B0C58A70049A0F3 /* ReserveAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReserveAlertViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +136,7 @@
 		A461B5942B07866D0049A0F3 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				A461B5F42B0C584D0049A0F3 /* ReserveAlert */,
 				A461B5B72B079A4F0049A0F3 /* WaitingDetail */,
 				A461B5B62B079A450049A0F3 /* StoreDetail */,
 				A461B5B52B079A3E0049A0F3 /* StoreList */,
@@ -355,6 +362,7 @@
 			isa = PBXGroup;
 			children = (
 				A461B5DB2B07A9030049A0F3 /* StoreDetailEntity.swift */,
+				A461B5F02B0BE0AD0049A0F3 /* ReserveEntity.swift */,
 			);
 			path = StoreDetail;
 			sourceTree = "<group>";
@@ -366,6 +374,31 @@
 				A461B5E32B08EB4B0049A0F3 /* Pretendard-SemiBold.otf */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		A461B5F42B0C584D0049A0F3 /* ReserveAlert */ = {
+			isa = PBXGroup;
+			children = (
+				A461B5F62B0C58900049A0F3 /* View */,
+				A461B5F52B0C58860049A0F3 /* ViewController */,
+			);
+			path = ReserveAlert;
+			sourceTree = "<group>";
+		};
+		A461B5F52B0C58860049A0F3 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				A461B5F92B0C58A70049A0F3 /* ReserveAlertViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		A461B5F62B0C58900049A0F3 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A461B5F72B0C589B0049A0F3 /* ReserveAlertView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -448,6 +481,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		398CCD642B09BBF700B78163 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -461,7 +495,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nexport PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -475,11 +509,13 @@
 				A461B5852B0688960049A0F3 /* ViewController.swift in Sources */,
 				A461B5C72B07A4230049A0F3 /* StoreListView.swift in Sources */,
 				A461B5A72B078A9A0049A0F3 /* UILabel+.swift in Sources */,
+				A461B5F12B0BE0AD0049A0F3 /* ReserveEntity.swift in Sources */,
 				A461B5C32B07A40F0049A0F3 /* WaitingDetailViewController.swift in Sources */,
 				A461B5EB2B08ED540049A0F3 /* UIImage+.swift in Sources */,
 				A461B5B32B0792840049A0F3 /* ColorLiterals.swift in Sources */,
 				A461B5D12B07A4670049A0F3 /* View.swift in Sources */,
 				A461B5CF2B07A44D0049A0F3 /* TablingListViewController.swift in Sources */,
+				A461B5FA2B0C58A70049A0F3 /* ReserveAlertViewController.swift in Sources */,
 				A461B5B12B07923D0049A0F3 /* UICollectionViewRegisterable.swift in Sources */,
 				A461B5CD2B07A4440049A0F3 /* StoreListViewController.swift in Sources */,
 				A461B5D92B07A8F30049A0F3 /* StoreListEntity.swift in Sources */,
@@ -495,6 +531,7 @@
 				A461B5E72B08EB5C0049A0F3 /* FontLiterals.swift in Sources */,
 				A461B5AF2B07900D0049A0F3 /* NSObject+.swift in Sources */,
 				A461B5E02B07D86F0049A0F3 /* ExampleCollectionViewCell.swift in Sources */,
+				A461B5F82B0C589B0049A0F3 /* ReserveAlertView.swift in Sources */,
 				A461B5A92B078C010049A0F3 /* UIColor+.swift in Sources */,
 				A461B5ED2B08F6900049A0F3 /* StringLiterals.swift in Sources */,
 				A461B5AD2B078FEA0049A0F3 /* UITableViewRegisterable.swift in Sources */,

--- a/Tabling-iOS/Tabling-iOS/Global/Extension/UILabel+.swift
+++ b/Tabling-iOS/Tabling-iOS/Global/Extension/UILabel+.swift
@@ -17,19 +17,42 @@ extension UILabel {
         attributedString.addAttribute(.foregroundColor, value: textColor, range: range)
         self.attributedText = attributedString
     }
+    
+    func partColorChange(targetString: String, textColor: UIColor) {
+        guard let existingText = self.text else {
+            return
+        }
+        
+        let existingAttributes = self.attributedText?.attributes(at: 0, effectiveRange: nil) ?? [:]
+        
+        let attributedStr = NSMutableAttributedString(string: existingText, attributes: existingAttributes)
+        
+        let range = (existingText as NSString).range(of: targetString)
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: textColor, range: range)
+        
+        self.attributedText = attributedStr
+    }
+    
     //행간, 자간 조절 메소드
     func setLineAndCharacterSpacing(font: UIFont) {
-        if let text = self.text {
-            let attributedStr = NSMutableAttributedString(string: text, attributes: [.font: font])
-            let style = NSMutableParagraphStyle()
-            style.lineSpacing = 1.5
-            attributedStr.addAttribute(NSAttributedString.Key.paragraphStyle,
-                                       value: style,
-                                       range: NSMakeRange(0, attributedStr.length))
-            attributedStr.addAttribute(NSAttributedString.Key.kern,
-                                       value: -0.025,
-                                       range: NSMakeRange(0, attributedStr.length))
-            self.attributedText = attributedStr
+        guard let existingText = self.text else {
+            return
         }
+        
+        let existingAttributes = self.attributedText?.attributes(at: 0, effectiveRange: nil) ?? [:]
+        
+        let attributedStr = NSMutableAttributedString(string: existingText, attributes: existingAttributes)
+        
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 1.5
+        attributedStr.addAttribute(NSAttributedString.Key.paragraphStyle,
+                                   value: style,
+                                   range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.kern,
+                                   value: -0.025,
+                                   range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.font, value: font, range: NSMakeRange(0, attributedStr.length))
+        
+        self.attributedText = attributedStr
     }
 }

--- a/Tabling-iOS/Tabling-iOS/Global/Literals/ColorLiterals.swift
+++ b/Tabling-iOS/Tabling-iOS/Global/Literals/ColorLiterals.swift
@@ -25,7 +25,7 @@ extension UIColor {
     }
     
     static var Gray000: UIColor {
-        return UIColor(hex: "#EAEAEA")
+        return UIColor(hex: "#F3F3F3")
     }
     
     static var Gray100: UIColor {

--- a/Tabling-iOS/Tabling-iOS/Global/Literals/StringLiterals.swift
+++ b/Tabling-iOS/Tabling-iOS/Global/Literals/StringLiterals.swift
@@ -13,6 +13,16 @@ enum I18N {
         static let nextButtonTitle = "다음으로"
     }
     
+    enum ReserveAlert {
+        static let reserveTitle = "대기 신청 완료"
+        static let waitingTitle = "대기번호"
+        static let waitingNumTitle = "번"
+        static let shopTitle = "매장명"
+        static let personTitle = "인원"
+        static let statusTitle = "신청상태"
+        static let reserveButtonTitle = "대기 내역 확인하기"
+    }
+    
     enum StoreDetail {
         
     }

--- a/Tabling-iOS/Tabling-iOS/Network/Entity/StoreDetail/ReserveEntity.swift
+++ b/Tabling-iOS/Tabling-iOS/Network/Entity/StoreDetail/ReserveEntity.swift
@@ -8,12 +8,13 @@
 import Foundation
 
 struct ReserveEntity: Codable {
-    let waitingNumber, beforeCount: Int
+    let orderID, waitingNumber, beforeCount: Int
     let shopName: String
     let personCount: Int
     let orderStatus: String
-
+    
     enum CodingKeys: String, CodingKey {
+        case orderID = "order_id"
         case waitingNumber = "waiting_number"
         case beforeCount = "before_count"
         case shopName = "shop_name"
@@ -24,6 +25,6 @@ struct ReserveEntity: Codable {
 
 extension ReserveEntity {
     static func reserveDummy() -> ReserveEntity {
-        return ReserveEntity(waitingNumber: 66, beforeCount: 4, shopName: "파이브가이즈 여의도", personCount: 2, orderStatus: "확정 예정")
+        return ReserveEntity(orderID: 2, waitingNumber: 86, beforeCount: 5, shopName: "파이브가이즈 여의도", personCount: 99, orderStatus: "확정 예정")
     }
 }

--- a/Tabling-iOS/Tabling-iOS/Network/Entity/StoreDetail/ReserveEntity.swift
+++ b/Tabling-iOS/Tabling-iOS/Network/Entity/StoreDetail/ReserveEntity.swift
@@ -1,0 +1,29 @@
+//
+//  ReserveEntity.swift
+//  Tabling-iOS
+//
+//  Created by 고아라 on 2023/11/21.
+//
+
+import Foundation
+
+struct ReserveEntity: Codable {
+    let waitingNumber, beforeCount: Int
+    let shopName: String
+    let personCount: Int
+    let orderStatus: String
+
+    enum CodingKeys: String, CodingKey {
+        case waitingNumber = "waiting_number"
+        case beforeCount = "before_count"
+        case shopName = "shop_name"
+        case personCount = "person_count"
+        case orderStatus = "order_status"
+    }
+}
+
+extension ReserveEntity {
+    static func reserveDummy() -> ReserveEntity {
+        return ReserveEntity(waitingNumber: 66, beforeCount: 4, shopName: "파이브가이즈 여의도", personCount: 2, orderStatus: "확정 예정")
+    }
+}

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -292,4 +292,12 @@ extension ReserveAlertView {
             break
         }
     }
+    
+    func setDataBind(model: ReserveEntity) {
+        waitingNum.text = String(model.waitingNumber)
+        infoTitle.text = "현재 내 앞 대기 \(model.beforeCount)팀"
+        shopLabel.text = model.shopName
+        personLabel.text = "\(model.personCount)명"
+        statusLabel.text = model.orderStatus
+    }
 }

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -56,7 +56,6 @@ final class ReserveAlertView: UIView {
     
     private let waitingNum: UILabel = {
         let label = UILabel()
-        label.text = "66"
         label.textColor = .TablingWhite
         label.font = .pretendardSemiBold(size: 24)
         return label
@@ -74,7 +73,6 @@ final class ReserveAlertView: UIView {
     
     private let infoTitle: UILabel = {
         let label = UILabel()
-        label.text = "현재 내 앞 대기 4팀"
         label.textColor = .TablingPrimary
         label.font = .pretendardSemiBold(size: 12)
         return label
@@ -97,7 +95,6 @@ final class ReserveAlertView: UIView {
     
     private let shopLabel: UILabel = {
         let label = UILabel()
-        label.text = "파이브가이즈 여의도"
         label.textColor = .Gray300
         label.font = .pretendardSemiBold(size: 14)
         return label
@@ -113,7 +110,6 @@ final class ReserveAlertView: UIView {
     
     private let personLabel: UILabel = {
         let label = UILabel()
-        label.text = "2명"
         label.textColor = .Gray300
         label.font = .pretendardSemiBold(size: 14)
         return label
@@ -129,7 +125,6 @@ final class ReserveAlertView: UIView {
     
     private let statusLabel: UILabel = {
         let label = UILabel()
-        label.text = "확정예정"
         label.textColor = .Gray300
         label.font = .pretendardSemiBold(size: 14)
         return label

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -201,8 +201,9 @@ extension ReserveAlertView {
         }
         
         waitingNumTitle.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(17)
+            $0.top.equalToSuperview().inset(16)
             $0.trailing.equalToSuperview().inset(25)
+            $0.height.equalTo(24)
         }
         
         waitingNum.snp.makeConstraints {
@@ -217,7 +218,7 @@ extension ReserveAlertView {
         }
         
         infoTitle.snp.makeConstraints {
-            $0.top.equalTo(waitingView.snp.bottom).offset(17)
+            $0.top.equalTo(waitingView.snp.bottom).offset(15)
             $0.leading.equalTo(infoIcon.snp.trailing)
         }
         

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -236,35 +236,37 @@ extension ReserveAlertView {
         shopTitle.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.leading.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
         }
         
         shopLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.trailing.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
+        }
+        
+        personTitle.snp.makeConstraints {
+            $0.top.equalTo(shopTitle.snp.bottom).offset(6)
+            $0.leading.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
+        }
+        
+        personLabel.snp.makeConstraints {
+            $0.top.equalTo(shopLabel.snp.bottom).offset(6)
+            $0.trailing.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
         }
         
         statusTitle.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(12)
             $0.leading.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
         }
         
         statusLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(12)
             $0.trailing.equalToSuperview().inset(12)
-        }
-        
-        personTitle.snp.makeConstraints {
-            $0.top.equalTo(shopTitle.snp.bottom)
-            $0.bottom.equalTo(statusTitle.snp.top)
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(12)
-        }
-        
-        personLabel.snp.makeConstraints {
-            $0.top.equalTo(shopLabel.snp.bottom)
-            $0.bottom.equalTo(statusLabel.snp.top)
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(12)
+            $0.height.equalTo(23)
         }
         
         detailButton.snp.makeConstraints {

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -50,14 +50,14 @@ final class ReserveAlertView: UIView {
         let label = UILabel()
         label.text = I18N.ReserveAlert.waitingTitle
         label.textColor = .TablingSecondary2
-        label.font = .pretendardSemiBold(size: 16)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         return label
     }()
     
     private let waitingNum: UILabel = {
         let label = UILabel()
         label.textColor = .TablingWhite
-        label.font = .pretendardSemiBold(size: 24)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 24))
         return label
     }()
     
@@ -65,7 +65,7 @@ final class ReserveAlertView: UIView {
         let label = UILabel()
         label.text = I18N.ReserveAlert.waitingNumTitle
         label.textColor = .Gray200
-        label.font = .pretendardSemiBold(size: 16)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         return label
     }()
     
@@ -74,7 +74,7 @@ final class ReserveAlertView: UIView {
     private let infoTitle: UILabel = {
         let label = UILabel()
         label.textColor = .TablingPrimary
-        label.font = .pretendardSemiBold(size: 12)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 12))
         return label
     }()
     
@@ -89,14 +89,14 @@ final class ReserveAlertView: UIView {
         let label = UILabel()
         label.text = I18N.ReserveAlert.shopTitle
         label.textColor = .Gray200
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
     private let shopLabel: UILabel = {
         let label = UILabel()
         label.textColor = .Gray300
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
@@ -104,14 +104,14 @@ final class ReserveAlertView: UIView {
         let label = UILabel()
         label.text = I18N.ReserveAlert.personTitle
         label.textColor = .Gray200
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
     private let personLabel: UILabel = {
         let label = UILabel()
         label.textColor = .Gray300
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
@@ -119,14 +119,14 @@ final class ReserveAlertView: UIView {
         let label = UILabel()
         label.text = I18N.ReserveAlert.statusTitle
         label.textColor = .Gray200
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
     private let statusLabel: UILabel = {
         let label = UILabel()
         label.textColor = .Gray300
-        label.font = .pretendardSemiBold(size: 14)
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
         return label
     }()
     
@@ -134,7 +134,7 @@ final class ReserveAlertView: UIView {
         let button = UIButton()
         button.backgroundColor = .TablingPrimary
         button.setTitle(I18N.ReserveAlert.reserveButtonTitle, for: .normal)
-        button.titleLabel?.font = .pretendardSemiBold(size: 14)
+        button.titleLabel?.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         button.titleLabel?.textColor = .TablingWhite
         button.layer.cornerRadius = 8
         return button
@@ -294,5 +294,10 @@ extension ReserveAlertView {
         shopLabel.text = model.shopName
         personLabel.text = "\(model.personCount)명"
         statusLabel.text = model.orderStatus
+        
+        waitingNum.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 24))
+        [infoTitle, shopLabel, personLabel, statusLabel].forEach {
+            $0.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 14))
+        }
     }
 }

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/View/ReserveAlertView.swift
@@ -1,0 +1,293 @@
+//
+//  ReserveAlertView.swift
+//  Tabling-iOS
+//
+//  Created by 고아라 on 2023/11/21.
+//
+
+import UIKit
+
+import SnapKit
+
+protocol ButtonDelegate: AnyObject {
+    func closeButtonTapped()
+    func detailButtonTappd()
+}
+
+final class ReserveAlertView: UIView {
+    
+    // MARK: - Properties
+    
+    weak var buttonDelegate: ButtonDelegate?
+    
+    // MARK: - UI Components
+    
+    private let closeButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.StoreDetail.ic_exit_circle, for: .normal)
+        return button
+    }()
+    
+    private let reserveTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.reserveTitle
+        label.textColor = .Gray700
+        label.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 20))
+        label.partColorChange(targetString: "대기 신청", textColor: .TablingSecondary1)
+        return label
+    }()
+    
+    private let waitingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .Gray600
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    private let waitingIcon: UIImageView = UIImageView(image: ImageLiterals.StoreDetail.ic_waiting)
+    
+    private let waitingTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.waitingTitle
+        label.textColor = .TablingSecondary2
+        label.font = .pretendardSemiBold(size: 16)
+        return label
+    }()
+    
+    private let waitingNum: UILabel = {
+        let label = UILabel()
+        label.text = "66"
+        label.textColor = .TablingWhite
+        label.font = .pretendardSemiBold(size: 24)
+        return label
+    }()
+    
+    private let waitingNumTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.waitingNumTitle
+        label.textColor = .Gray200
+        label.font = .pretendardSemiBold(size: 16)
+        return label
+    }()
+    
+    private let infoIcon: UIImageView = UIImageView(image: ImageLiterals.StoreDetail.ic_info)
+    
+    private let infoTitle: UILabel = {
+        let label = UILabel()
+        label.text = "현재 내 앞 대기 4팀"
+        label.textColor = .TablingPrimary
+        label.font = .pretendardSemiBold(size: 12)
+        return label
+    }()
+    
+    private let detailView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .Gray000
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    private let shopTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.shopTitle
+        label.textColor = .Gray200
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let shopLabel: UILabel = {
+        let label = UILabel()
+        label.text = "파이브가이즈 여의도"
+        label.textColor = .Gray300
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let personTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.personTitle
+        label.textColor = .Gray200
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let personLabel: UILabel = {
+        let label = UILabel()
+        label.text = "2명"
+        label.textColor = .Gray300
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let statusTitle: UILabel = {
+        let label = UILabel()
+        label.text = I18N.ReserveAlert.statusTitle
+        label.textColor = .Gray200
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.text = "확정예정"
+        label.textColor = .Gray300
+        label.font = .pretendardSemiBold(size: 14)
+        return label
+    }()
+    
+    private let detailButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .TablingPrimary
+        button.setTitle(I18N.ReserveAlert.reserveButtonTitle, for: .normal)
+        button.titleLabel?.font = .pretendardSemiBold(size: 14)
+        button.titleLabel?.textColor = .TablingWhite
+        button.layer.cornerRadius = 8
+        return button
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .Gray500
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension ReserveAlertView {
+    func setUI() {
+        backgroundColor = .TablingWhite
+        layer.cornerRadius = 8
+    }
+    
+    func setHierarchy() {
+        waitingView.addSubviews(waitingIcon, waitingTitle, waitingNumTitle, waitingNum)
+        detailView.addSubviews(shopTitle, shopLabel, personTitle, personLabel, statusTitle, statusLabel)
+        addSubviews(closeButton, reserveTitle, waitingView, infoIcon, infoTitle, detailView, detailButton)
+    }
+    
+    func setLayout() {
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(19)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.size.equalTo(24)
+        }
+        
+        reserveTitle.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(41)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        waitingView.snp.makeConstraints {
+            $0.top.equalTo(reserveTitle.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(284)
+            $0.height.equalTo(52)
+        }
+        
+        waitingIcon.snp.makeConstraints {
+            $0.centerY.equalToSuperview().inset(18)
+            $0.leading.equalToSuperview().inset(20)
+            $0.size.equalTo(16)
+        }
+        
+        waitingTitle.snp.makeConstraints {
+            $0.centerY.equalToSuperview().inset(14)
+            $0.leading.equalTo(waitingIcon.snp.trailing).offset(8)
+        }
+        
+        waitingNumTitle.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(17)
+            $0.trailing.equalToSuperview().inset(25)
+        }
+        
+        waitingNum.snp.makeConstraints {
+            $0.centerY.equalToSuperview().inset(12)
+            $0.trailing.equalTo(waitingNumTitle.snp.leading).offset(-5)
+        }
+        
+        infoIcon.snp.makeConstraints {
+            $0.top.equalTo(waitingView.snp.bottom).offset(12)
+            $0.leading.equalTo(waitingView.snp.leading)
+            $0.size.equalTo(24)
+        }
+        
+        infoTitle.snp.makeConstraints {
+            $0.top.equalTo(waitingView.snp.bottom).offset(17)
+            $0.leading.equalTo(infoIcon.snp.trailing)
+        }
+        
+        detailView.snp.makeConstraints {
+            $0.top.equalTo(infoIcon.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview().inset(16)
+            $0.width.equalTo(283)
+            $0.height.equalTo(105)
+        }
+        
+        shopTitle.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(12)
+        }
+        
+        shopLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.trailing.equalToSuperview().inset(12)
+        }
+        
+        statusTitle.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(12)
+        }
+        
+        statusLabel.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(12)
+            $0.trailing.equalToSuperview().inset(12)
+        }
+        
+        personTitle.snp.makeConstraints {
+            $0.top.equalTo(shopTitle.snp.bottom)
+            $0.bottom.equalTo(statusTitle.snp.top)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(12)
+        }
+        
+        personLabel.snp.makeConstraints {
+            $0.top.equalTo(shopLabel.snp.bottom)
+            $0.bottom.equalTo(statusLabel.snp.top)
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(12)
+        }
+        
+        detailButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(33)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(56)
+        }
+    }
+    
+    func setAddTarget() {
+        closeButton.addTarget(self, action: #selector(isTapped), for: .touchUpInside)
+        detailButton.addTarget(self, action: #selector(isTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    func isTapped(_ sender: UIButton) {
+        switch sender {
+        case closeButton:
+            buttonDelegate?.closeButtonTapped()
+        case detailButton:
+            buttonDelegate?.detailButtonTappd()
+        default:
+            break
+        }
+    }
+}

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
@@ -1,0 +1,63 @@
+//
+//  ReserveAlertViewController.swift
+//  Tabling-iOS
+//
+//  Created by 고아라 on 2023/11/21.
+//
+
+import UIKit
+
+import SnapKit
+
+final class ReserveAlertViewController: UIViewController {
+    
+    // MARK: - UI Components
+    
+    private let reserveAlertView = ReserveAlertView()
+    
+    // MARK: - Life Cycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setHierachy()
+        setLayout()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+extension ReserveAlertViewController {
+    func setUI() {
+        view.backgroundColor = .black.withAlphaComponent(0.5)
+    }
+    
+    func setHierachy() {
+        view.addSubview(reserveAlertView)
+    }
+    
+    func setDelegate() {
+        reserveAlertView.buttonDelegate = self
+    }
+    
+    func setLayout() {
+        reserveAlertView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(320)
+            $0.height.equalTo(415)
+        }
+    }
+}
+
+extension ReserveAlertViewController: ButtonDelegate {
+    func closeButtonTapped() {
+        self.dismiss(animated: false)
+    }
+    
+    func detailButtonTappd() {
+        let nav = WaitingDetailViewController()
+        nav.modalPresentationStyle = .fullScreen
+        self.present(nav, animated: false)
+    }
+}

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
@@ -11,6 +11,10 @@ import SnapKit
 
 final class ReserveAlertViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    private let reserveEntity: ReserveEntity = ReserveEntity.reserveDummy()
+    
     // MARK: - UI Components
     
     private let reserveAlertView = ReserveAlertView()
@@ -24,6 +28,7 @@ final class ReserveAlertViewController: UIViewController {
         setHierachy()
         setLayout()
         setDelegate()
+        fetchData()
     }
 }
 
@@ -47,6 +52,11 @@ extension ReserveAlertViewController {
             $0.width.equalTo(320)
             $0.height.equalTo(415)
         }
+    }
+    
+    func fetchData() {
+        dump(reserveEntity)
+        reserveAlertView.setDataBind(model: reserveEntity)
     }
 }
 

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveAlert/ViewController/ReserveAlertViewController.swift
@@ -55,7 +55,6 @@ extension ReserveAlertViewController {
     }
     
     func fetchData() {
-        dump(reserveEntity)
         reserveAlertView.setDataBind(model: reserveEntity)
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
- 원격줄서기 완료 팝업 뷰 구현

🚨 **참고 사항**
- UILabel에서 특정 색상만 바꾸는 extension 추가했습니다!
```swift
func partColorChange(targetString: String, textColor: UIColor) {
        guard let existingText = self.text else {
            return
        }
        
        let existingAttributes = self.attributedText?.attributes(at: 0, effectiveRange: nil) ?? [:]
        
        let attributedStr = NSMutableAttributedString(string: existingText, attributes: existingAttributes)
        
        let range = (existingText as NSString).range(of: targetString)
        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: textColor, range: range)
        
        self.attributedText = attributedStr
}
```
- 팝업 뷰 띄울 때 아래 코드 넣어주시면 됩니다!
```swift
 let nav = ReserveAlertViewController()
nav.modalPresentationStyle = .overFullScreen
self.present(nav, animated: false)
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|PNG|<img src = "https://github.com/DOSOPT-CDS-TABLING/Tabling-iOS/assets/79412889/f9884ead-659e-4bc9-9cd5-d23576361ca1" width ="250">|

📟 **관련 이슈**
- Resolved: #10 
