### PR TITLE
[✨Feat] #41 - 대기 상세 이용 상태에 따른 분기 처리

### DIFF
--- a/Tabling-iOS/Tabling-iOS/Global/Literals/StringLiterals.swift
+++ b/Tabling-iOS/Tabling-iOS/Global/Literals/StringLiterals.swift
@@ -17,6 +17,8 @@ enum I18N {
         static let waitingStatusTitle = "대기상태"
         static let totalSalesTitle = "총 금액"
         static let requestTitle = "요청사항"
+        static let statusDoneLabel = "이용이 완료되었어요"
+        static let statusIngLabel = "대기중이에요"
     }
     
     enum ReserveAlert {

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/HomeView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/HomeView.swift
@@ -268,7 +268,7 @@ extension HomeView {
             $0.top.equalTo(storePickTagTitle.snp.bottom).offset(12)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview()
-            $0.height.equalTo(74)
+            $0.height.equalTo(80)
         }
         amenityTitle.snp.makeConstraints {
             $0.leading.equalTo(storePickTagTitle)

--- a/Tabling-iOS/Tabling-iOS/Presentation/WaitingDetail/View/WaitingDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/WaitingDetail/View/WaitingDetailView.swift
@@ -341,8 +341,20 @@ extension WaitingDetailView {
     
     func setDataBind(model: WaitingDetailEntity) {
         storeNameLabel.text = model.shopName
+        
+        switch model.orderStatus {
+        case "이용 완료":
+            currentStatusLabel.text = "이용이 완료되었어요"
+            queueNumLabel.textColor = .TablingWhite
+            queueNumLabel.text = "0팀"
+            waitingNumTitleLabel.textColor = .Gray100
+        case "이용 예정":
+            currentStatusLabel.text = "대기중이에요"
+            queueNumLabel.text = "\(model.beforeCount)팀"
+        default:
+            waitingNumLabel.text = "서비스 오류"
+        }
         waitingNumTitleLabel.text = "대기번호 #\(model.waitingNumber)"
-        queueNumLabel.text = "\(model.beforeCount)팀"
         waitingDateLabel.text = "\(model.orderDate)"
         waitingheadCountLabel.text = "\(model.personCount)명"
         waitingStatusLabel.text = "\(model.orderStatus)"

--- a/Tabling-iOS/Tabling-iOS/Presentation/WaitingDetail/View/WaitingDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/WaitingDetail/View/WaitingDetailView.swift
@@ -341,15 +341,14 @@ extension WaitingDetailView {
     
     func setDataBind(model: WaitingDetailEntity) {
         storeNameLabel.text = model.shopName
-        
         switch model.orderStatus {
         case "이용 완료":
-            currentStatusLabel.text = "이용이 완료되었어요"
+            currentStatusLabel.text = I18N.WaitingDetail.statusDoneLabel
             queueNumLabel.textColor = .TablingWhite
             queueNumLabel.text = "0팀"
             waitingNumTitleLabel.textColor = .Gray100
         case "이용 예정":
-            currentStatusLabel.text = "대기중이에요"
+            currentStatusLabel.text = I18N.WaitingDetail.statusIngLabel
             queueNumLabel.text = "\(model.beforeCount)팀"
         default:
             waitingNumLabel.text = "서비스 오류"


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
- 이용 상태에 따른 뷰 분기처리를 했습니다
- 요청사항 폰트 컬러를 변경했습니다

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/DOSOPT-CDS-TABLING/Tabling-iOS/assets/107970815/e74ff33a-6ba4-43a2-bfe8-5d2a47995217" width ="250">|

📟 **관련 이슈**
- Resolved: #41
