### PR TITLE
[REFACTOR] #49 - 매장 상세 뷰 하단 커스텀 탭바 리팩토링

### DIFF
--- a/Tabling-iOS/.swiftlint.yml
+++ b/Tabling-iOS/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
 - file_length
 - identifier_name
 - function_body_length
+- nesting
 # 린트 과정에서 무시할 파일 경로
 excluded:
 - Tabling-iOS/Application/AppDelegate.swift

--- a/Tabling-iOS/Tabling-iOS.xcodeproj/project.pbxproj
+++ b/Tabling-iOS/Tabling-iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2F6F98352B1721DE000D8D1D /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F98342B1721DE000D8D1D /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		394685562B0F79D7000E7674 /* MenuCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394685552B0F79D7000E7674 /* MenuCollectionViewCell.swift */; };
 		394685582B0F8B21000E7674 /* MenuCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394685572B0F8B21000E7674 /* MenuCollectionHeaderView.swift */; };
+		3950DC252B1D6F8B00CCCD83 /* CustomTabBarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950DC242B1D6F8B00CCCD83 /* CustomTabBarHeaderView.swift */; };
 		398CCD662B09BC6400B78163 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 398CCD652B09BC6400B78163 /* .swiftlint.yml */; };
 		39951FF32B14344C0029824E /* StoreDetailImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39951FF22B14344C0029824E /* StoreDetailImageCollectionViewCell.swift */; };
 		39951FF52B1444230029824E /* ImageScrollCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39951FF42B1444230029824E /* ImageScrollCollectionView.swift */; };
@@ -96,6 +97,7 @@
 		2F6F98342B1721DE000D8D1D /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		394685552B0F79D7000E7674 /* MenuCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCollectionViewCell.swift; sourceTree = "<group>"; };
 		394685572B0F8B21000E7674 /* MenuCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCollectionHeaderView.swift; sourceTree = "<group>"; };
+		3950DC242B1D6F8B00CCCD83 /* CustomTabBarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarHeaderView.swift; sourceTree = "<group>"; };
 		398CCD652B09BC6400B78163 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		39951FF22B14344C0029824E /* StoreDetailImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDetailImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		39951FF42B1444230029824E /* ImageScrollCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageScrollCollectionView.swift; sourceTree = "<group>"; };
@@ -471,6 +473,7 @@
 			isa = PBXGroup;
 			children = (
 				39D09F8F2B0AE04F00F27995 /* StoreDetailBottomTabView.swift */,
+				3950DC242B1D6F8B00CCCD83 /* CustomTabBarHeaderView.swift */,
 				A461B5C42B07A4180049A0F3 /* StoreDetailView.swift */,
 				39EC84DB2B0BAD82006F684C /* HomeView.swift */,
 				39EC84DD2B0BAD89006F684C /* AllMenuView.swift */,
@@ -728,6 +731,7 @@
 				A4498F292B11B19200E1DFC7 /* StoreDetailService.swift in Sources */,
 				39951FF52B1444230029824E /* ImageScrollCollectionView.swift in Sources */,
 				A461B5CD2B07A4440049A0F3 /* StoreListViewController.swift in Sources */,
+				3950DC252B1D6F8B00CCCD83 /* CustomTabBarHeaderView.swift in Sources */,
 				39EC84DC2B0BAD82006F684C /* HomeView.swift in Sources */,
 				A461B5D92B07A8F30049A0F3 /* StoreListEntity.swift in Sources */,
 				2F6F98352B1721DE000D8D1D /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,

--- a/Tabling-iOS/Tabling-iOS/Presentation/ReserveBottomSheet/ViewController/ReserveBottomSheetViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/ReserveBottomSheet/ViewController/ReserveBottomSheetViewController.swift
@@ -34,7 +34,6 @@ final class ReserveBottomSheetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUI()
         setHierarchy()
         setLayout()
         setDelegate()
@@ -44,8 +43,6 @@ final class ReserveBottomSheetViewController: UIViewController {
 
 // MARK: - Extensions
 extension ReserveBottomSheetViewController {
-    func setUI() {
-    }
     
     func setHierarchy() {
         view.addSubviews(dimmedBackView, reserveBottomSheetView)
@@ -67,14 +64,16 @@ extension ReserveBottomSheetViewController {
     }
     
     func hideBottomSheet() {
-        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn,
+                       animations: {
             self.dimmedBackView.alpha = 0.0
             self.view.layoutIfNeeded()
-        }) { _ in
+        },
+                       completion: { _ in
             if self.presentingViewController != nil {
                 self.dismiss(animated: true)
             }
-        }
+        })
     }
     
     func setupGestureRecognizer() {

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
@@ -1,0 +1,130 @@
+//
+//  CustomTabBarHeaderView.swift
+//  Tabling-iOS
+//
+//  Created by 민 on 12/4/23.
+//
+
+import UIKit
+
+class CustomTabBarHeaderView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let segmentControl: UISegmentedControl = {
+        let segment = UISegmentedControl()
+        segment.selectedSegmentTintColor = .clear
+        segment.setBackgroundImage(UIImage(), for: .normal, barMetrics: .default)
+        segment.setDividerImage(UIImage(), forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+        
+        let titles = [
+            I18N.StoreDetail.homeSegmentControlTitle,
+            I18N.StoreDetail.menuSegmentControlTitle,
+            I18N.StoreDetail.reviewSegmentControlTitle
+        ]
+        for (index, title) in titles.enumerated() {
+            segment.insertSegment(withTitle: title, at: index, animated: true)
+            segment.setWidth(92, forSegmentAt: index)
+        }
+
+        let normalAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.Gray200,
+            .font: UIFont.pretendardSemiBold(size: 16)
+        ]
+        let selectedAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.Gray800,
+            .font: UIFont.pretendardSemiBold(size: 16)
+        ]
+        segment.selectedSegmentIndex = 0
+        segment.setTitleTextAttributes(normalAttributes, for: .normal)
+        segment.setTitleTextAttributes(selectedAttributes, for: .selected)
+
+        return segment
+    }()
+    
+    private let underLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .Gray600
+        return view
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+extension CustomTabBarHeaderView {
+    
+    func setHierarchy() {
+        self.addSubviews(segmentControl, underLineView)
+    }
+    
+    func setLayout() {
+        segmentControl.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(52)
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(34)
+        }
+        
+        underLineView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.width.equalTo(92)
+            $0.height.equalTo(2)
+            $0.leading.equalTo(segmentControl.snp.leading)
+        }
+    }
+    
+    func setAddTarget() {
+        segmentControl.addTarget(self, action: #selector(didChangeValue(_:)), for: .valueChanged)
+        segmentControl.addTarget(self, action: #selector(changeSegmentedControlLinePosition(_:)), for: .valueChanged)
+    }
+    
+    @objc
+    private func didChangeValue(_ segment: UISegmentedControl) {
+//        switch segment.selectedSegmentIndex {
+//        case 0:
+//            homeView.isHidden = false
+//            allMenuView.isHidden = true
+//            recentReviewView.isHidden = true
+//        case 1:
+//            homeView.isHidden = true
+//            allMenuView.isHidden = false
+//            recentReviewView.isHidden = true
+//        default:
+//            homeView.isHidden = true
+//            allMenuView.isHidden = true
+//            recentReviewView.isHidden = false
+//        }
+    }
+    
+    @objc
+    func changeSegmentedControlLinePosition(_ segment: UISegmentedControl) {
+        let leadingDistance = Int(92 * CGFloat(segment.selectedSegmentIndex) + (92 - self.underLineView.bounds.width) * 0.5)
+        UIView.animate(withDuration: 0.2, animations: {
+            self.underLineView.snp.updateConstraints { $0.leading.equalTo(self.segmentControl.snp.leading).offset(leadingDistance) }
+            self.layoutIfNeeded()
+        })
+    }
+    
+    func setRegisterCell() {
+        
+    }
+    
+    func setDataBind() {
+        
+    }
+}

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
@@ -7,7 +7,17 @@
 
 import UIKit
 
+protocol CustomTabBarHeaderViewDelegate: AnyObject {
+    func firstSegmentClicked()
+    func secondSegmentClicked()
+    func thirdSegmentClicked()
+}
+
 class CustomTabBarHeaderView: UIView {
+    
+    // MARK: - Properties
+    
+    weak var customTabBarHeaderViewDelegate: CustomTabBarHeaderViewDelegate?
     
     // MARK: - UI Components
     
@@ -89,35 +99,31 @@ extension CustomTabBarHeaderView {
     }
     
     func setAddTarget() {
-        segmentControl.addTarget(self, action: #selector(didChangeValue(_:)), for: .valueChanged)
-        segmentControl.addTarget(self, action: #selector(changeSegmentedControlLinePosition(_:)), for: .valueChanged)
+        segmentControl.addTarget(self, action: #selector(didChangeValue(_:)), for: .allEvents)
     }
     
     @objc
     private func didChangeValue(_ segment: UISegmentedControl) {
-//        switch segment.selectedSegmentIndex {
-//        case 0:
-//            homeView.isHidden = false
-//            allMenuView.isHidden = true
-//            recentReviewView.isHidden = true
-//        case 1:
-//            homeView.isHidden = true
-//            allMenuView.isHidden = false
-//            recentReviewView.isHidden = true
-//        default:
-//            homeView.isHidden = true
-//            allMenuView.isHidden = true
-//            recentReviewView.isHidden = false
-//        }
+        switch segment.selectedSegmentIndex {
+        case 0:
+            changeSegmentedControlLinePosition(selectedSegmentIndex: 0)
+            customTabBarHeaderViewDelegate?.firstSegmentClicked()
+        case 1:
+            changeSegmentedControlLinePosition(selectedSegmentIndex: 1)
+            customTabBarHeaderViewDelegate?.secondSegmentClicked()
+        default:
+            changeSegmentedControlLinePosition(selectedSegmentIndex: 2)
+            customTabBarHeaderViewDelegate?.thirdSegmentClicked()
+        }
     }
     
-    @objc
-    func changeSegmentedControlLinePosition(_ segment: UISegmentedControl) {
-        let leadingDistance = Int(92 * CGFloat(segment.selectedSegmentIndex) + (92 - self.underLineView.bounds.width) * 0.5)
+    func changeSegmentedControlLinePosition(selectedSegmentIndex: Int) {
+        let leadingDistance = Int(92 * CGFloat(selectedSegmentIndex) + (92 - self.underLineView.bounds.width) * 0.5)
         UIView.animate(withDuration: 0.2, animations: {
             self.underLineView.snp.updateConstraints { $0.leading.equalTo(self.segmentControl.snp.leading).offset(leadingDistance) }
             self.layoutIfNeeded()
         })
+
     }
     
     func setRegisterCell() {

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
@@ -99,7 +99,7 @@ extension CustomTabBarHeaderView {
             $0.bottom.equalToSuperview()
             $0.width.equalTo(92)
             $0.height.equalTo(2)
-            $0.leading.equalTo(stackView.snp.leading)
+            $0.leading.equalTo(stackView.snp.leading).offset(-3)
         }
     }
     
@@ -114,7 +114,6 @@ extension CustomTabBarHeaderView {
             homeButton.isHighlighted = false
             allMenuButton.isHighlighted = true
             recentReviewButton.isHighlighted = false
-
         default:
             homeButton.isHighlighted = false
             allMenuButton.isHighlighted = false
@@ -123,7 +122,7 @@ extension CustomTabBarHeaderView {
     }
     
     func changeSegmentedControlLinePosition(selectedSegmentIndex: Int) {
-        let leadingDistance = Int(92 * CGFloat(selectedSegmentIndex) + (92 - self.underLineView.bounds.width) * 0.5)
+        let leadingDistance = Int(95 * CGFloat(selectedSegmentIndex) + (95 - self.underLineView.bounds.width) * 0.5)
         UIView.animate(withDuration: 0.2, animations: {
             self.underLineView.snp.updateConstraints {
                 $0.leading.equalTo(self.stackView.snp.leading).offset(leadingDistance) }

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/CustomTabBarHeaderView.swift
@@ -33,7 +33,7 @@ class CustomTabBarHeaderView: UIView {
         let button = UIButton()
         button.isHighlighted = true
         button.setTitle(I18N.StoreDetail.homeSegmentControlTitle, for: .normal)
-        button.titleLabel?.font = UIFont.pretendardSemiBold(size: 16)
+        button.titleLabel?.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         button.setTitleColor(.Gray200, for: .normal)
         button.setTitleColor(.Gray800, for: .highlighted)
         return button
@@ -42,7 +42,7 @@ class CustomTabBarHeaderView: UIView {
     private let allMenuButton: UIButton = {
         let button = UIButton()
         button.setTitle(I18N.StoreDetail.menuSegmentControlTitle, for: .normal)
-        button.titleLabel?.font = UIFont.pretendardSemiBold(size: 16)
+        button.titleLabel?.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         button.setTitleColor(.Gray200, for: .normal)
         button.setTitleColor(.Gray800, for: .highlighted)
         return button
@@ -51,7 +51,7 @@ class CustomTabBarHeaderView: UIView {
     private let recentReviewButton: UIButton = {
         let button = UIButton()
         button.setTitle(I18N.StoreDetail.reviewSegmentControlTitle, for: .normal)
-        button.titleLabel?.font = UIFont.pretendardSemiBold(size: 16)
+        button.titleLabel?.setLineAndCharacterSpacing(font: .pretendardSemiBold(size: 16))
         button.setTitleColor(.Gray200, for: .normal)
         button.setTitleColor(.Gray800, for: .highlighted)
         return button
@@ -131,23 +131,22 @@ extension CustomTabBarHeaderView {
     }
     
     func setAddTarget() {
-        homeButton.addTarget(self, action: #selector(homeButtonCicked), for: .touchUpInside)
-        allMenuButton.addTarget(self, action: #selector(allMenuButtonCicked), for: .touchUpInside)
-        recentReviewButton.addTarget(self, action: #selector(recentReviewButtonClicked), for: .touchUpInside)
+        homeButton.addTarget(self, action: #selector(isTabButtonClicked), for: .touchUpInside)
+        allMenuButton.addTarget(self, action: #selector(isTabButtonClicked), for: .touchUpInside)
+        recentReviewButton.addTarget(self, action: #selector(isTabButtonClicked), for: .touchUpInside)
     }
     
     @objc
-    private func homeButtonCicked() {
-        customTabBarHeaderViewDelegate?.firstSegmentClicked()
-    }
-    
-    @objc
-    private func allMenuButtonCicked() {
-        customTabBarHeaderViewDelegate?.secondSegmentClicked()
-    }
-    
-    @objc
-    private func recentReviewButtonClicked() {
-        customTabBarHeaderViewDelegate?.thirdSegmentClicked()
+    private func isTabButtonClicked(_ sender: UIButton) {
+        switch sender {
+        case homeButton:
+            customTabBarHeaderViewDelegate?.firstSegmentClicked()
+        case allMenuButton:
+            customTabBarHeaderViewDelegate?.secondSegmentClicked()
+        case recentReviewButton:
+            customTabBarHeaderViewDelegate?.thirdSegmentClicked()
+        default:
+            break
+        }
     }
 }

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
@@ -71,7 +71,7 @@ final class StoreDetailView: UIView {
         return label
     }()
     
-    private let customTabBarHeaderView = CustomTabBarHeaderView()
+    let customTabBarHeaderView = CustomTabBarHeaderView()
     
     private let firstGrayView = {
         let view = UIView()

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
@@ -73,7 +73,7 @@ final class StoreDetailView: UIView {
     
     let customTabBarHeaderView = CustomTabBarHeaderView()
     
-    private let firstGrayView = {
+    let firstGrayView = {
         let view = UIView()
         view.backgroundColor = .Gray000
         return view
@@ -85,7 +85,7 @@ final class StoreDetailView: UIView {
         return view
     }()
     
-    private let secondGrayView = {
+    let secondGrayView = {
         let view = UIView()
         view.backgroundColor = .Gray000
         return view
@@ -96,7 +96,7 @@ final class StoreDetailView: UIView {
         return view
     }()
     
-    private let thirdGrayView = {
+    let thirdGrayView = {
         let view = UIView()
         view.backgroundColor = .Gray000
         return view

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
@@ -71,42 +71,7 @@ final class StoreDetailView: UIView {
         return label
     }()
     
-    private let segmentControl: UISegmentedControl = {
-        let segment = UISegmentedControl()
-        segment.selectedSegmentTintColor = .clear
-        segment.setBackgroundImage(UIImage(), for: .normal, barMetrics: .default)
-        segment.setDividerImage(UIImage(), forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
-        
-        let titles = [
-            I18N.StoreDetail.homeSegmentControlTitle,
-            I18N.StoreDetail.menuSegmentControlTitle,
-            I18N.StoreDetail.reviewSegmentControlTitle
-        ]
-        for (index, title) in titles.enumerated() {
-            segment.insertSegment(withTitle: title, at: index, animated: true)
-            segment.setWidth(92, forSegmentAt: index)
-        }
-
-        let normalAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.Gray200,
-            .font: UIFont.pretendardSemiBold(size: 16)
-        ]
-        let selectedAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.Gray800,
-            .font: UIFont.pretendardSemiBold(size: 16)
-        ]
-        segment.selectedSegmentIndex = 0
-        segment.setTitleTextAttributes(normalAttributes, for: .normal)
-        segment.setTitleTextAttributes(selectedAttributes, for: .selected)
-
-        return segment
-    }()
-    
-    private let underLineView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .Gray600
-        return view
-    }()
+    private let customTabBarHeaderView = CustomTabBarHeaderView()
     
     private let firstGrayView = {
         let view = UIView()
@@ -149,7 +114,6 @@ final class StoreDetailView: UIView {
         
         setHierarchy()
         setLayout()
-        setAddTarget()
     }
     
     @available(*, unavailable)
@@ -161,7 +125,7 @@ final class StoreDetailView: UIView {
 // MARK: - Extensions
 extension StoreDetailView {
     func setHierarchy() {
-        self.addSubviews(storeNameLabel, storeAddressLabel, lookMapTitleButton, lookMapButton, starStackView, starScoreLabel, segmentControl, underLineView, firstGrayView, recentReviewView, secondGrayView, allMenuView, thirdGrayView, homeView)
+        self.addSubviews(storeNameLabel, storeAddressLabel, lookMapTitleButton, lookMapButton, starStackView, starScoreLabel, customTabBarHeaderView, firstGrayView, recentReviewView, secondGrayView, allMenuView, thirdGrayView, homeView)
     }
     
     func setLayout() {
@@ -201,23 +165,15 @@ extension StoreDetailView {
             $0.centerY.equalTo(starStackView.snp.centerY)
         }
         
-        segmentControl.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(52)
-            $0.top.equalTo(starStackView.snp.bottom).offset(17)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(34)
-        }
-        
-        underLineView.snp.makeConstraints {
-            $0.top.equalTo(segmentControl.snp.bottom).offset(21)
-            $0.width.equalTo(92)
-            $0.height.equalTo(2)
-            $0.leading.equalTo(segmentControl.snp.leading)
+        customTabBarHeaderView.snp.makeConstraints {
+            $0.top.equalTo(starScoreLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(50)
         }
         
         firstGrayView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(underLineView.snp.bottom)
+            $0.top.equalTo(customTabBarHeaderView.snp.bottom)
             $0.height.equalTo(8)
         }
         
@@ -249,38 +205,6 @@ extension StoreDetailView {
             $0.top.equalTo(thirdGrayView.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }
-    }
-    
-    func setAddTarget() {
-        segmentControl.addTarget(self, action: #selector(didChangeValue(_:)), for: .valueChanged)
-        segmentControl.addTarget(self, action: #selector(changeSegmentedControlLinePosition(_:)), for: .valueChanged)
-    }
-    
-    @objc
-    private func didChangeValue(_ segment: UISegmentedControl) {
-//        switch segment.selectedSegmentIndex {
-//        case 0:
-//            homeView.isHidden = false
-//            allMenuView.isHidden = true
-//            recentReviewView.isHidden = true
-//        case 1:
-//            homeView.isHidden = true
-//            allMenuView.isHidden = false
-//            recentReviewView.isHidden = true
-//        default:
-//            homeView.isHidden = true
-//            allMenuView.isHidden = true
-//            recentReviewView.isHidden = false
-//        }
-    }
-    
-    @objc
-    func changeSegmentedControlLinePosition(_ segment: UISegmentedControl) {
-        let leadingDistance = Int(92 * CGFloat(segment.selectedSegmentIndex) + (92 - self.underLineView.bounds.width) * 0.5)
-        UIView.animate(withDuration: 0.2, animations: {
-            self.underLineView.snp.updateConstraints { $0.leading.equalTo(self.segmentControl.snp.leading).offset(leadingDistance) }
-            self.layoutIfNeeded()
-        })
     }
     
     func setDataBind(model: StoreDetailEntity) {

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/View/StoreDetailView.swift
@@ -108,7 +108,7 @@ final class StoreDetailView: UIView {
         return view
     }()
     
-    private let grayView: UIView = {
+    private let firstGrayView = {
         let view = UIView()
         view.backgroundColor = .Gray000
         return view
@@ -120,8 +120,20 @@ final class StoreDetailView: UIView {
         return view
     }()
     
+    private let secondGrayView = {
+        let view = UIView()
+        view.backgroundColor = .Gray000
+        return view
+    }()
+    
     let allMenuView: AllMenuView = {
         let view = AllMenuView()
+        return view
+    }()
+    
+    private let thirdGrayView = {
+        let view = UIView()
+        view.backgroundColor = .Gray000
         return view
     }()
     
@@ -149,7 +161,7 @@ final class StoreDetailView: UIView {
 // MARK: - Extensions
 extension StoreDetailView {
     func setHierarchy() {
-        self.addSubviews(storeNameLabel, storeAddressLabel, lookMapTitleButton, lookMapButton, starStackView, starScoreLabel, segmentControl, underLineView, grayView, recentReviewView, allMenuView, homeView)
+        self.addSubviews(storeNameLabel, storeAddressLabel, lookMapTitleButton, lookMapButton, starStackView, starScoreLabel, segmentControl, underLineView, firstGrayView, recentReviewView, secondGrayView, allMenuView, thirdGrayView, homeView)
     }
     
     func setLayout() {
@@ -203,24 +215,38 @@ extension StoreDetailView {
             $0.leading.equalTo(segmentControl.snp.leading)
         }
         
-        grayView.snp.makeConstraints {
+        firstGrayView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(underLineView.snp.bottom)
             $0.height.equalTo(8)
         }
         
         homeView.snp.makeConstraints {
-            $0.top.equalTo(grayView.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(firstGrayView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(681)
+        }
+        
+        secondGrayView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(homeView.snp.bottom)
+            $0.height.equalTo(8)
         }
         
         allMenuView.snp.makeConstraints {
-            $0.top.equalTo(grayView.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(secondGrayView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(702)
+        }
+        
+        thirdGrayView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(allMenuView.snp.bottom)
+            $0.height.equalTo(8)
         }
         
         recentReviewView.snp.makeConstraints {
-            $0.top.equalTo(grayView.snp.bottom)
+            $0.top.equalTo(thirdGrayView.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }
     }
@@ -232,20 +258,20 @@ extension StoreDetailView {
     
     @objc
     private func didChangeValue(_ segment: UISegmentedControl) {
-        switch segment.selectedSegmentIndex {
-        case 0:
-            homeView.isHidden = false
-            allMenuView.isHidden = true
-            recentReviewView.isHidden = true
-        case 1:
-            homeView.isHidden = true
-            allMenuView.isHidden = false
-            recentReviewView.isHidden = true
-        default:
-            homeView.isHidden = true
-            allMenuView.isHidden = true
-            recentReviewView.isHidden = false
-        }
+//        switch segment.selectedSegmentIndex {
+//        case 0:
+//            homeView.isHidden = false
+//            allMenuView.isHidden = true
+//            recentReviewView.isHidden = true
+//        case 1:
+//            homeView.isHidden = true
+//            allMenuView.isHidden = false
+//            recentReviewView.isHidden = true
+//        default:
+//            homeView.isHidden = true
+//            allMenuView.isHidden = true
+//            recentReviewView.isHidden = false
+//        }
     }
     
     @objc

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
@@ -279,25 +279,34 @@ extension StoreDetailViewController: UIScrollViewDelegate {
         
         /// 스크롤에 따른 커스텀 헤더 이벤트 변경
         if yOffset >= storeDetailView.homeView.frame.origin.y && yOffset <= storeDetailView.homeView.frame.origin.y+storeDetailView.homeView.frame.height {
-            normalCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 0)
+            normalCustomTabBarHeaderView.changeCustomHeader(index: 0)
+            stickyCustomTabBarHeaderView.changeCustomHeader(index: 0)
         } else if yOffset >= storeDetailView.allMenuView.frame.origin.y && yOffset <= storeDetailView.allMenuView.frame.origin.y+storeDetailView.allMenuView.frame.height {
-            stickyCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 1)
+            normalCustomTabBarHeaderView.changeCustomHeader(index: 1)
+            stickyCustomTabBarHeaderView.changeCustomHeader(index: 1)
         } else if yOffset >= storeDetailView.recentReviewView.frame.origin.y {
-            stickyCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 2)
+            normalCustomTabBarHeaderView.changeCustomHeader(index: 2)
+            stickyCustomTabBarHeaderView.changeCustomHeader(index: 2)
         }
     }
 }
 
 extension StoreDetailViewController: CustomTabBarHeaderViewDelegate {
     func firstSegmentClicked() {
+//        normalCustomTabBarHeaderView.changeCustomHeader(index: 0)
+//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 0)
         scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.homeView.frame.origin.y-8), animated: true)
     }
     
     func secondSegmentClicked() {
+//        normalCustomTabBarHeaderView.changeCustomHeader(index: 1)
+//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 1)
         scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.allMenuView.frame.origin.y-8), animated: true)
     }
     
     func thirdSegmentClicked() {
+//        normalCustomTabBarHeaderView.changeCustomHeader(index: 2)
+//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 2)
         scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.recentReviewView.frame.origin.y-8), animated: true)
     }
 }

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
@@ -22,7 +22,6 @@ final class StoreDetailViewController: UIViewController {
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.showsVerticalScrollIndicator = true
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.bounces = false
         return scrollView
     }()
@@ -68,6 +67,13 @@ final class StoreDetailViewController: UIViewController {
         return view
     }()
     
+    private let stickyCustomTabBarHeaderView = {
+        let view = CustomTabBarHeaderView()
+        view.backgroundColor = .TablingWhite
+        view.isHidden = true
+        return view
+    }()
+    
     private lazy var storeTagCollectionView = storeDetailView.homeView.storeTagCollectionView
     private lazy var homeCollectionView = storeDetailView.allMenuView.homeCollectionView
     private lazy var detailTableView = storeDetailView.recentReviewView.detailTableView
@@ -95,7 +101,7 @@ extension StoreDetailViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(scrollView, storeDetailBottomTabView)
+        view.addSubviews(scrollView, storeDetailBottomTabView, stickyCustomTabBarHeaderView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(imagescrollCollectionView, waitingTeamLabel, photoCountLabel, storeDetailView)
     }
@@ -140,6 +146,12 @@ extension StoreDetailViewController {
         storeDetailView.snp.makeConstraints {
             $0.top.equalTo(imagescrollCollectionView.snp.bottom).inset(57)
             $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        stickyCustomTabBarHeaderView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(90)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(50)
         }
     }
     
@@ -247,6 +259,12 @@ extension StoreDetailViewController: UITableViewDataSource {
 extension StoreDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let yOffset = scrollView.contentOffset.y
+
+        /// Sticky headerView 높이 고정
+        let shouldShowSticky = yOffset >= 197
+        stickyCustomTabBarHeaderView.isHidden = !shouldShowSticky
+        
+        /// 스크롤에 따른 navigationBar 속성 변경
         if yOffset > 0 {
             navigationItem.leftBarButtonItem?.tintColor = .Gray800
             navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .Gray800 }

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
@@ -278,13 +278,13 @@ extension StoreDetailViewController: UIScrollViewDelegate {
         }
         
         /// 스크롤에 따른 커스텀 헤더 이벤트 변경
-        if yOffset >= storeDetailView.homeView.frame.origin.y && yOffset <= storeDetailView.homeView.frame.origin.y+storeDetailView.homeView.frame.height {
+        if yOffset >= storeDetailView.homeView.frame.origin.y && yOffset < storeDetailView.homeView.frame.origin.y+storeDetailView.homeView.frame.height {
             normalCustomTabBarHeaderView.changeCustomHeader(index: 0)
             stickyCustomTabBarHeaderView.changeCustomHeader(index: 0)
-        } else if yOffset >= storeDetailView.allMenuView.frame.origin.y && yOffset <= storeDetailView.allMenuView.frame.origin.y+storeDetailView.allMenuView.frame.height {
+        } else if yOffset >= storeDetailView.homeView.frame.origin.y+storeDetailView.homeView.frame.height && yOffset < storeDetailView.allMenuView.frame.origin.y+storeDetailView.allMenuView.frame.height {
             normalCustomTabBarHeaderView.changeCustomHeader(index: 1)
             stickyCustomTabBarHeaderView.changeCustomHeader(index: 1)
-        } else if yOffset >= storeDetailView.recentReviewView.frame.origin.y {
+        } else if yOffset >= storeDetailView.allMenuView.frame.origin.y+storeDetailView.allMenuView.frame.height {
             normalCustomTabBarHeaderView.changeCustomHeader(index: 2)
             stickyCustomTabBarHeaderView.changeCustomHeader(index: 2)
         }
@@ -293,21 +293,15 @@ extension StoreDetailViewController: UIScrollViewDelegate {
 
 extension StoreDetailViewController: CustomTabBarHeaderViewDelegate {
     func firstSegmentClicked() {
-//        normalCustomTabBarHeaderView.changeCustomHeader(index: 0)
-//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 0)
-        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.homeView.frame.origin.y-8), animated: true)
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.firstGrayView.frame.origin.y), animated: true)
     }
     
     func secondSegmentClicked() {
-//        normalCustomTabBarHeaderView.changeCustomHeader(index: 1)
-//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 1)
-        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.allMenuView.frame.origin.y-8), animated: true)
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.secondGrayView.frame.origin.y), animated: true)
     }
     
     func thirdSegmentClicked() {
-//        normalCustomTabBarHeaderView.changeCustomHeader(index: 2)
-//        stickyCustomTabBarHeaderView.changeCustomHeader(index: 2)
-        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.recentReviewView.frame.origin.y-8), animated: true)
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.thirdGrayView.frame.origin.y), animated: true)
     }
 }
 

--- a/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
+++ b/Tabling-iOS/Tabling-iOS/Presentation/StoreDetail/ViewController/StoreDetailViewController.swift
@@ -67,6 +67,8 @@ final class StoreDetailViewController: UIViewController {
         return view
     }()
     
+    private lazy var normalCustomTabBarHeaderView = storeDetailView.customTabBarHeaderView
+    
     private let stickyCustomTabBarHeaderView = {
         let view = CustomTabBarHeaderView()
         view.backgroundColor = .TablingWhite
@@ -149,7 +151,7 @@ extension StoreDetailViewController {
         }
         
         stickyCustomTabBarHeaderView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(90)
+            $0.top.equalToSuperview().inset(92)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(50)
         }
@@ -167,6 +169,8 @@ extension StoreDetailViewController {
         imageCollectionView.delegate = self
         storeTagCollectionView.delegate = self
         storeTagCollectionView.dataSource = self
+        normalCustomTabBarHeaderView.customTabBarHeaderViewDelegate = self
+        stickyCustomTabBarHeaderView.customTabBarHeaderViewDelegate = self
     }
     
     func setNavigationBar() {
@@ -261,7 +265,7 @@ extension StoreDetailViewController: UIScrollViewDelegate {
         let yOffset = scrollView.contentOffset.y
 
         /// Sticky headerView 높이 고정
-        let shouldShowSticky = yOffset >= 197
+        let shouldShowSticky = yOffset >= storeDetailView.customTabBarHeaderView.frame.origin.y + 55
         stickyCustomTabBarHeaderView.isHidden = !shouldShowSticky
         
         /// 스크롤에 따른 navigationBar 속성 변경
@@ -272,6 +276,29 @@ extension StoreDetailViewController: UIScrollViewDelegate {
             navigationItem.leftBarButtonItem?.tintColor = .TablingWhite
             navigationItem.rightBarButtonItems?.forEach { $0.tintColor = .TablingWhite }
         }
+        
+        /// 스크롤에 따른 커스텀 헤더 이벤트 변경
+        if yOffset >= storeDetailView.homeView.frame.origin.y && yOffset <= storeDetailView.homeView.frame.origin.y+storeDetailView.homeView.frame.height {
+            normalCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 0)
+        } else if yOffset >= storeDetailView.allMenuView.frame.origin.y && yOffset <= storeDetailView.allMenuView.frame.origin.y+storeDetailView.allMenuView.frame.height {
+            stickyCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 1)
+        } else if yOffset >= storeDetailView.recentReviewView.frame.origin.y {
+            stickyCustomTabBarHeaderView.changeSegmentedControlLinePosition(selectedSegmentIndex: 2)
+        }
+    }
+}
+
+extension StoreDetailViewController: CustomTabBarHeaderViewDelegate {
+    func firstSegmentClicked() {
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.homeView.frame.origin.y-8), animated: true)
+    }
+    
+    func secondSegmentClicked() {
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.allMenuView.frame.origin.y-8), animated: true)
+    }
+    
+    func thirdSegmentClicked() {
+        scrollView.setContentOffset(CGPoint(x: 0, y: storeDetailView.recentReviewView.frame.origin.y-8), animated: true)
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
매장 상세뷰를 원래 디자이너 선생님들이 원하셨던 화면처럼 구현했습니다!

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- .swiftlint - nesting 추가 (사유 : 중복 클로저를 사용할 경우 Warning이 발생하는 부분인데 Config에서 사용중이어서 무시하도록 설정)
- SegmentedControl로 구현했던 커스텀 탭바 -> StackView 속 Button으로 구현 (사유 : SegmentedContol을 현재 해당 Index가 Active 되어있는 상태일 경우 다시 클릭을 해도 반응하지 않음. 하지만, 테이블링에서는 Index가 활성화되어있는 상태에서도 항상 각 탭의 상단으로 이동하는 로직이 필요했음)

📸 **스크린샷**
|StickyHeader 구현| 탭바 클릭시 자동 스크롤 | 유저 스크롤시 탭바 움직임 |
|:--:|:--:|:--:|
| ![stickyheader구현](https://github.com/DOSOPT-CDS-TABLING/Tabling-iOS/assets/69389288/5944ac58-690a-4459-9ac2-89ea3a50f55d) | ![Simulator Screen Recording - iPhone 15 Pro - 2023-12-10 at 20 03 08](https://github.com/DOSOPT-CDS-TABLING/Tabling-iOS/assets/69389288/0e8d4dbd-50c5-476a-aa7f-5a6753e272c6) | ![Simulator Screen Recording - iPhone 15 Pro - 2023-12-10 at 20 03 41](https://github.com/DOSOPT-CDS-TABLING/Tabling-iOS/assets/69389288/cdee79ca-b55c-413a-939d-c9c63eb32de9) |

📟 **관련 이슈**
- Resolved: #49 
